### PR TITLE
Validate that badge numbers are exactly ten digits on create and update

### DIFF
--- a/src/Controller/BadgesController.php
+++ b/src/Controller/BadgesController.php
@@ -9,6 +9,16 @@ class BadgesController extends AppController {
     parent::beforeFilter($event);
   }
 
+  protected function _flashBadgeSaveError($badge, $fallback) {
+    $number_errors = $badge->errors('number');
+    if (!empty($number_errors)) {
+      $this->Flash->error(reset($number_errors));
+      return;
+    }
+
+    $this->Flash->error(__($fallback));
+  }
+
   public function isAuthorized($user) {
     if (in_array($this->request->action, ['users'])) {
       if (isset($user['id']) && $user['id'] == $this->request->pass[0]) {
@@ -53,7 +63,7 @@ class BadgesController extends AppController {
         if ($this->Badges->save($badge)) {
           return $this->redirect(['controller' => 'Badges', 'action' => 'edit', $badge->id]);
         } else {
-          $this->Flash->error(__('Badge could not be created. Please try again.'));
+          $this->_flashBadgeSaveError($badge, 'Badge could not be created. Please try again.');
         }
       }
     }
@@ -167,7 +177,7 @@ class BadgesController extends AppController {
         if ($this->Badges->save($badge)) {
           $this->Flash->success(__('Badge updated.'));
         } else {
-          $this->Flash->error(__('Badge could not be created. Please try again.'));
+          $this->_flashBadgeSaveError($badge, 'Badge could not be created. Please try again.');
         }
       }
     }
@@ -302,7 +312,7 @@ class BadgesController extends AppController {
         if ($this->Badges->save($badge)) {
           $this->Flash->success(__('Badge has been activated.'));
         } else {
-          $this->Flash->error(__('Badge activation failed. Double check your badge number and try again.'));
+          $this->_flashBadgeSaveError($badge, 'Badge activation failed. Double check your badge number and try again.');
         }
       }
     }

--- a/src/Model/Table/BadgesTable.php
+++ b/src/Model/Table/BadgesTable.php
@@ -53,13 +53,16 @@ class BadgesTable extends Table {
         ]
       ])
       ->add('number', [
-        'numeric' => [
-          'rule' => 'numeric',
-          'message' => 'Badge number can only include numbers.'
+        'tenDigitText' => [
+          'rule' => function($value, $context){
+            if ($value === null || $value === '') { return true; }
+            return preg_match('/^\d{10}$/', (string)$value) === 1;
+          },
+          'message' => 'Badge number must be exactly ten digits.'
         ],
         'emptyOrUnique' => [
           'rule' => function($value, $context){
-            if (empty($value)) { return true; }
+            if ($value === null || $value === '') { return true; }
             $count = $this->find()
               ->where(['number' => $value])
               ->count();


### PR DESCRIPTION
Implemented validation for the badge number for badge creation by admin and user, and for badge update. 

This is how it looks  now

<img width="1186" height="824" alt="image" src="https://github.com/user-attachments/assets/bd858ed7-fb81-4970-a3e6-aa8bc4a1ab86" />
