### PR TITLE
Rediret to My Badge after login

### DIFF
--- a/src/Controller/PagesController.php
+++ b/src/Controller/PagesController.php
@@ -59,6 +59,18 @@ class PagesController extends AppController
         if (!empty($path[1])) {
             $subpage = $path[1];
         }
+
+        if ($page == 'home') {
+            $auth_user = $this->Auth->user();
+            if (!empty($auth_user['id'])) {
+                return $this->redirect([
+                    'controller' => 'Badges',
+                    'action' => 'users',
+                    'user_id' => $auth_user['id']
+                ]);
+            }
+        }
+
         $this->set(compact('page', 'subpage'));
 
         try {


### PR DESCRIPTION
Currently, after login, the users are redirected to an empty home page. That only shows the disclaimer. It is very confusing for the users. Not clear what to do next.

<img width="638" height="421" alt="image" src="https://github.com/user-attachments/assets/7c24a548-27e5-4a5d-9769-ce34acf7cb8a" />.     
    
So, I've changed it to redirect to the `My Badge` page after the login.
