### PR TITLE
Preserve server-side local changes for review

### DIFF
--- a/src/Controller/BadgesController.php
+++ b/src/Controller/BadgesController.php
@@ -3,6 +3,7 @@ namespace App\Controller;
 
 use App\Controller\AppController;
 use Cake\Event\Event;
+Use Cake\Log\Log;
 
 class BadgesController extends AppController {
   public function beforeFilter(Event $event) {
@@ -195,6 +196,7 @@ class BadgesController extends AppController {
   }
 
   public function index($list = null) {
+
     $this->paginate = [
       'contain' => ['Users'],
       'sortWhitelist' => ['Users.first_name', 'Users.last_name', 'Users.username', 'Users.email', 'description', 'number', 'status'],

--- a/src/Controller/EndpointsController.php
+++ b/src/Controller/EndpointsController.php
@@ -18,6 +18,7 @@ class EndpointsController extends AppController {
     // Access to endpoints is protected by a valid mm_auth value in the post array
     if (empty($this->request->data['mm_auth']) || $this->request->data['mm_auth'] != Configure::read('Endpoint.authorization')) {
       echo 'Unauthorized';
+
       exit;
     }
 
@@ -90,71 +91,108 @@ class EndpointsController extends AppController {
     // Badge not found, but since this addon was cancelled it's inconsequential
     Log::error('WHMCS addon cancellation successfully removed a family member user badge in Maker Manager for user with WHMCS user id ' . $this->request->data['userid'] . ', service id ' . $this->request->data['serviceid'] . ' and addon id ' . $this->request->data['addonid'], ['scope' => ['users']]);
   }
+
+
     public function userAdd(){
-        $usersTable = TableRegistry::get('Users');
-        if($existing_user = $usersTable->find()->where(['whmcs_user_id' => $this->request->data['user_id']])->first())
-        {
-            if (!empty($existing_user)) {
-                // Create a new active directory account, if one didn't previously exist
-                $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-                $password = substr(str_shuffle($chars), 0, 16);
-                $existing_user->createActiveDirectoryAccount($password, true);
+      Log::error('userAdd: called '.microtime());
+      Log::error('Data passed: '.var_export($this->request->data, true));
 
-                $existing_user->changeActiveDirectoryPassword($this->request->data['password']);
+      $usersTable = TableRegistry::get('Users');
+      $user = $usersTable->newEntity();
+      // prefilling some data because the validator requires it
+      // data will be updated with clientAdd hook
+      $user->first_name = $this->request->data['firstname'];
+      $user->last_name = $this->request->data['lastname'];
+      $user->username = substr(str_shuffle('abcdefghijklmnopqrstuvwxyz'), 0, 8);
+      $user->email = $this->request->data['email'];
+      $user->whmcs_user_id = $this->request->data['user_id'];
+      $user->whmcs_real_user_id = $this->request->data['user_id'];
+      $user->whmcs_user_id_password = $this->request->data['password'];
+      $user->ad_active = 0;
+      $user->is_admin = 0;
+      $user->kdetest = 1;
 
-                Log::error('WHMCS client successfully changed Active Directory password for WHMCS user id ' . $this->request->data['userid'] . '.', ['scope' => ['users']]);
-            } else {
-                $this->_sendEmail('WHMCS client failed Active Directory password changing in Maker Manager for WHMCS user id ' . $this->request->data['user_id'] . '. WHMCS user not found in Maker Manager.');
-                Log::error('WHMCS client failed Active Directory password changing in Maker Manager for WHMCS user id ' . $this->request->data['user_id'] . '. WHMCS user not found in Maker Manager.', ['scope' => ['users']]);
-            }
-        }
-
+      $user_data = [
+          'first_name' => $this->request->data['firstname'],
+          'last_name' => $this->request->data['lastname'],
+          'username' => $username,
+          'email' => $this->request->data['email'],
+          'phone' => ' ',
+          'address_1' => ' ',
+          'city' => ' ',
+          'state' => ' ',
+          'zip' => ' ',
+          'ad_active' => 0,
+          'is_admin' => 0,
+          'whmcs_user_id' => $this->request->data['user_id'],
+          'whmcs_real_user_id' => $this->request->data['user_id'],
+          'whmcs_user_id_password' => $this->request->data['password']
+      ];
+      //$user = $usersTable->patchEntity($user, $user_data);
+      if ($usersTable->save($user)) {
+          Log::error('userAdd: WHMCS user_id created');
+          Log::error('user_data: '.var_export($user_data, true));
+          Log::error('Data passed: '.var_export($this->request->data, true));
+          Log::error(var_export($user->errors(), true));
+      } else {
+          Log::error('userAdd: WHMCS user_id creation failed');
+          Log::error('user_data: '.var_export($user_data, true));
+          Log::error(var_export($user->getErrors(), true));
+      }
     }
+
   public function clientAdd() {
     // Create user in App
-    $usersTable = TableRegistry::get('Users');
+    // Hook from WHMCS: https://developers.whmcs.com/hooks-reference/client/#clientadd
+    Log::error('clientAdd: called '.microtime());
+
+//    Log::error('Attempting to add client (Creating AD): '.$this->request->data['username'].' || '.$this->request->data['password'], ['scope' => ['secure']]);
+
+      $usersTable = TableRegistry::get('Users');
 
     $existing_user = $usersTable->find()
-      ->where(['whmcs_user_id' => $this->request->data['userid']])
+      ->where(['whmcs_real_user_id' => $this->request->data['user_id']])
       ->first();
 
     if (empty($existing_user)) {
-      $user = $usersTable->newEntity();
-      $user_data = [
-        'first_name' => $this->request->data['firstname'],
-        'last_name' => $this->request->data['lastname'],
-        'username' => strtolower($this->request->data['username']),
-        'email' => $this->request->data['email'],
-        'phone' => $this->request->data['phonenumber'],
-        'address_1' => $this->request->data['address1'],
-        'address_2' => $this->request->data['address2'],
-        'city' => $this->request->data['city'],
-        'state' => $this->request->data['state'],
-        'zip' => $this->request->data['postcode'],
-        'whmcs_user_id' => $this->request->data['userid']
-];
-  //Attempt to log variable - Freddy
-      Log::error(var_export($this->request->data, true));
-$user = $usersTable->patchEntity($user, $user_data);
-      if ($usersTable->save($user)) {
-        $user->createActiveDirectoryAccount($this->request->data['password']);
-        Log::error('New WHMCS client successfully created in Maker Manager for WHMCS user id ' . $this->request->data['userid'] . '.', ['scope' => ['users']]);
-      } else {
-        $this->_sendEmail('New WHMCS client failed creation in Maker Manager for WHMCS user id ' . $this->request->data['userid']);
-        Log::error('New WHMCS client failed creation in Maker Manager for WHMCS user id ' . $this->request->data['userid'] . '. Errors in next logged message.', ['scope' => ['users']]);
-        Log::error(var_export($user->errors(), true), ['scope' => ['users']]);
-      }
+        Log::error('clientAdd: WHMCS user_id not in database, can not proceed');
+	Log::error('Data passed: '.var_export($this->request->data, true));
     } else {
-      Log::error('Possible Conflict: New WHMCS client skipped creation in Maker Manager (whmcs_user_id already exists in MM) for WHMCS user id ' . $this->request->data['userid'] . '. Errors in next logged message.', ['scope' => ['users']]);
+        // update record
+        $user_data = [
+            'first_name' => $this->request->data['firstname'],
+            'last_name' => $this->request->data['lastname'],
+            'email' => $this->request->data['email'],
+            'address_1' => $this->request->data['address1'],
+            'address_2' => $this->request->data['address2'],
+            'city' => $this->request->data['city'],
+            'state' => $this->request->data['state'],
+            'zip' => $this->request->data['postcode'],
+            'phone' => $this->request->data['phonenumber'],
+            'username' => strtolower($this->request->data['username']),
+            'ad_active' => 0,
+            'is_admin' => 0,
+            'whmcs_user_id' => $this->request->data['client_id']
+        ];
+        $existing_user = $usersTable->patchEntity($existing_user, $user_data);
+        if ($usersTable->save($existing_user)) {
+            // success
+            $existing_user->createActiveDirectoryAccount($existing_user->whmcs_user_id_password);
+            Log::error('New WHMCS client successfully created in Maker Manager for WHMCS user id ' . $this->request->data['client_id'] . '.', ['scope' => ['users']]);
+        } else {
+            $this->_sendEmail('New WHMCS client failed creation in Maker Manager for WHMCS user id ' . $this->request->data['client_id']);
+            Log::error('New WHMCS client failed creation in Maker Manager for WHMCS user id ' . $this->request->data['client_id'] . '. Errors in next logged message.', ['scope' => ['users']]);
+            Log::error(var_export($usersTable->getErrors(), true), ['scope' => ['users']]);
+        }
     }
+    Log::error(var_export($this->request->data, true));
   }
 
   public function clientChangePassword() {
     // Update user's password in active directory
     $usersTable = TableRegistry::get('Users');
     $user = $usersTable->find()
-      ->where(['whmcs_user_id' => $this->request->data['userid']])
-      ->andWhere(['user_id IS' => null])
+      ->where(['whmcs_user_id' => $this->request->data['clientid']])
       ->first();
 
     if (!empty($user)) {
@@ -165,10 +203,10 @@ $user = $usersTable->patchEntity($user, $user_data);
 
       $user->changeActiveDirectoryPassword($this->request->data['password']);
 
-      Log::error('WHMCS client successfully changed Active Directory password for WHMCS user id ' . $this->request->data['userid'] . '.', ['scope' => ['users']]);
+      Log::error('WHMCS client successfully changed Active Directory password for WHMCS user id ' . $this->request->data['clientid'] . '.', ['scope' => ['users']]);
     } else {
-      $this->_sendEmail('WHMCS client failed Active Directory password changing in Maker Manager for WHMCS user id ' . $this->request->data['userid'] . '. WHMCS user not found in Maker Manager.');
-      Log::error('WHMCS client failed Active Directory password changing in Maker Manager for WHMCS user id ' . $this->request->data['userid'] . '. WHMCS user not found in Maker Manager.', ['scope' => ['users']]);
+      $this->_sendEmail('WHMCS client failed Active Directory password changing in Maker Manager for WHMCS user id ' . $this->request->data['clientid'] . '. WHMCS user not found in Maker Manager.');
+      Log::error('WHMCS client failed Active Directory password changing in Maker Manager for WHMCS user id ' . $this->request->data['clientid'] . '. WHMCS user not found in Maker Manager.', ['scope' => ['users']]);
     }
   }
 

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -6,6 +6,7 @@ use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
 use Cake\ORM\TableRegistry;
+use Cake\Log\Log;
 
 class UsersController extends AppController {
   public function beforeFilter(Event $event) {
@@ -84,6 +85,7 @@ class UsersController extends AppController {
         ]);
 
         $user = $this->Users->patchEntity($user, $merged_account_data);
+	Log::error($user);
         if ($this->Users->save($user)) {
           $success = $user->createActiveDirectoryAccount($this->request->data['password']);
           if ($success == true) {

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -61,7 +61,16 @@ class User extends Entity {
     if ($bind) {
       return $ldap;
     }
-    
+
+   /*
+    * Added error handling below.
+    * Jared Fowkes - 2023-12-30
+    */
+    $error = ldap_error($ldap);
+    $errno = ldap_errno($ldap);
+    error_log("LDAP bind failed for RDN $ldap_rdn: Error $errno: $error");
+    ldap_close($ldap);
+ 
     return false;
   }
   

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -44,5 +44,24 @@ $this->prepend('body_attrs', ' class="' . strtolower(implode(' ', [$this->reques
 
     <?= $this->fetch('script') ?>
 <?= $this->element('Static/mascot') ?>
+    <script>
+    $('form').each((i,elem)=>{
+        $(elem).on("submit", (evt)=>{
+            $(elem).find('button[type=submit]').each((bI,btn)=>{
+                $(btn).prop('disabled', true);
+            });
+        });
+    });
+    </script>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-TSBVKCC0GS"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-TSBVKCC0GS');
+</script>
   </body>
 </html>

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -53,15 +53,5 @@ $this->prepend('body_attrs', ' class="' . strtolower(implode(' ', [$this->reques
         });
     });
     </script>
-
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-TSBVKCC0GS"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-TSBVKCC0GS');
-</script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

These changes were found as uncommitted local modifications on the production server (`dms-mm3`). They are being submitted for review so they can be merged into `master` and the server can be brought into sync with the repo.

- **`BadgesController.php`** — Adds `use Cake\Log\Log` import
- **`EndpointsController.php`** — Rewrites `userAdd` and `clientAdd` to align with WHMCS 8.x hook payload changes (field name renames: `userid` → `user_id`/`client_id`, `clientid`, etc.)
- **`UsersController.php`** — Adds `use Cake\Log\Log` import and diagnostic logging during user account merge
- **`User.php`** — Adds LDAP bind error handling with `ldap_error`/`ldap_errno` logging (credit: Jared Fowkes, 2023-12-30)
- **`default.ctp`** — Adds form-submit button disabler (prevents double-submit) and ~Google Analytics tag~

## Notes

- The `EndpointsController` changes contain several `Log::error` debug statements and a `kdetest` field that may warrant cleanup before or after merging.
- The Google Analytics tag (`G-TSBVKCC0GS`) in `default.ctp` may be removed in a follow-up PR if not desired.

## Test plan

- [ ] Verify WHMCS `userAdd` and `clientAdd` hooks fire correctly with WHMCS 8.x
- [ ] Confirm LDAP bind failures now log an error instead of silently returning false
- [ ] Verify form submit disabler does not break any forms (check badge activation, user add, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)